### PR TITLE
Add loader into the end of the loaders name

### DIFF
--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -12,14 +12,14 @@ module.exports = {
     rules: [
       {
         test: /\.vue$/,
-        loader: 'vue',
+        loader: 'vue-loader',
         options: {
           sass: "vue-style-loader!css-loader!sass?indentedSyntax"
         }
       },
       {
         test: /\.js$/,
-        loader: 'babel',
+        loader: 'babel-loader',
         exclude: /node_modules/
       },
       {


### PR DESCRIPTION
New version of node needs word 'loader' explicitly at the end of the loader name.